### PR TITLE
Move ECB encryption mode to end of list

### DIFF
--- a/crypt/examples.html
+++ b/crypt/examples.html
@@ -152,11 +152,11 @@ thead td { font-weight: bold }</style></head>
     <p class="des 3des rijndael aes twofish blowfish rc2">
       Encryption Mode:<br />
       <select>
-        <option value="ecb">ECB</option>
         <option value="cbc">CBC</option>
         <option value="ctr">CTR</option>
         <option value="ofb">OFB</option>
         <option value="cfb">CFB</option>
+        <option value="ecb">ECB</option>
       </select>
     </p>
     <p>


### PR DESCRIPTION
Refs https://github.com/phpseclib/phpseclib/issues/882:
> Their interactive documentation also dangerously defaults to ECB mode, which is the worst block cipher mode.

This PR moves the ECB mode to the end of the selection list.