### PR TITLE
Recommend random IV generation for each encryption

### DIFF
--- a/crypt/examples.html
+++ b/crypt/examples.html
@@ -243,8 +243,9 @@ $cipher = new Crypt_<span class="aes">AES</span><span class="rijndael">Rijndael<
 </span><span class="pbkdf2">$cipher->setPassword('whatever');
 // the following does the same thing:
 //$cipher->setPassword('whatever', 'pbkdf2', 'sha1', 'phpseclib/salt', 1000<span class="rc4">, 128 / 8</span><span class="aes">, <span class="k128">128</span><span class="k192">192</span><span class="k256">256</span> / 8</span><span class="rijndael">, <span class="kr128">128</span><span class="kr160">160</span><span class="kr192">192</span><span class="kr224">224</span><span class="kr256">256</span> / 8</span>);
-</span><span class="des 3des aes rijndael"><span class="cbc ctr ofb cfb">// IV defaults to all-NULLs if not explicitly defined;
+</span><span class="des 3des aes rijndael"><span class="cbc ctr ofb cfb">// The IV defaults to all-NULLs if not explicitly defined;
 // it should be randomly generated for each encryption
+// and its length should equal the key length.
 $cipher->setIV('...');
 </span></span><span class="padding"><span class="aes rijndael des 3des"><span class="cbc ecb">$cipher->disablePadding();
 </span></span></span>

--- a/crypt/examples.html
+++ b/crypt/examples.html
@@ -243,7 +243,9 @@ $cipher = new Crypt_<span class="aes">AES</span><span class="rijndael">Rijndael<
 </span><span class="pbkdf2">$cipher->setPassword('whatever');
 // the following does the same thing:
 //$cipher->setPassword('whatever', 'pbkdf2', 'sha1', 'phpseclib/salt', 1000<span class="rc4">, 128 / 8</span><span class="aes">, <span class="k128">128</span><span class="k192">192</span><span class="k256">256</span> / 8</span><span class="rijndael">, <span class="kr128">128</span><span class="kr160">160</span><span class="kr192">192</span><span class="kr224">224</span><span class="kr256">256</span> / 8</span>);
-</span><span class="des 3des aes rijndael"><span class="cbc ctr ofb cfb">//$cipher->setIV('...'); // defaults to all-NULLs if not explicitely defined
+</span><span class="des 3des aes rijndael"><span class="cbc ctr ofb cfb">// IV defaults to all-NULLs if not explicitly defined;
+// it should be randomly generated for each encryption
+$cipher->setIV('...');
 </span></span><span class="padding"><span class="aes rijndael des 3des"><span class="cbc ecb">$cipher->disablePadding();
 </span></span></span>
 $size = 10 * 1024;


### PR DESCRIPTION
Refs https://github.com/phpseclib/phpseclib/issues/907#issuecomment-168575823.

This is based on the following from [Wikipedia](https://en.wikipedia.org/wiki/Block_cipher_mode_of_operation#Initialization_vector_.28IV.29) (emphasis mine):

> An initialization vector has different security requirements than a key, so the IV usually does not need to be secret. **However, in most cases, it is important that an initialization vector is never reused under the same key.** For CBC and CFB, reusing an IV leaks some information about the first block of plaintext, and about any common prefix shared by the two messages. For OFB and CTR, reusing an IV completely destroys security.[6] This can be seen because both modes effectively create a bitstream that is XORed with the plaintext, and this bitstream is dependent on the password and IV only. Reusing a bitstream destroys security. In CBC mode, the IV must, in addition, be unpredictable at encryption time; in particular, the (previously) common practice of re-using the last ciphertext block of a message as the IV for the next message is insecure (for example, this method was used by SSL 2.0). If an attacker knows the IV (or the previous block of ciphertext) before he specifies the next plaintext, he can check his guess about plaintext of some block that was encrypted with the same key before (this is known as the TLS CBC IV attack).

Note: Since the documentation still refers to the 1.0 branch, the "[IV] defaults to all-NULLs if not explicitely defined" was not removed (see https://github.com/phpseclib/phpseclib/pull/926). The goal of this PR is to recommend defining the IV nevertheless.