### PR TITLE
HTML validation errors fix

### DIFF
--- a/crypt/examples.html
+++ b/crypt/examples.html
@@ -159,17 +159,15 @@ thead td { font-weight: bold }</style></head>
         <option value="ecb">ECB</option>
       </select>
     </p>
-    <p>
-      <div class="cbc">
-      <div class="3des">
-      Chaining:<br />
-      <select>
-        <option value="outer">Outer</option>
-        <option value="inner">Inner</option>
-      </select>
-      </div>
-      </div>
-    </p>
+    <div class="cbc">
+    <div class="3des">
+    Chaining:<br />
+    <select>
+      <option value="outer">Outer</option>
+      <option value="inner">Inner</option>
+    </select>
+    </div>
+    </div>
     <p class="aes twofish">
       Key Length:<br />
       <select>
@@ -205,14 +203,12 @@ thead td { font-weight: bold }</style></head>
         <option value="pbkdf2">PBKDF2</option>
       </select>
     </p>
-    <p>
-      <div class="des 3des rijndael aes">
-      <div class="cbc ecb">
-      <button value="padding" class="buttonOff">Enable Padding</button>
-      <button value="padding" class="buttonOn disableCode">Disable Padding</button>
-      </div>
-      </div>
-    </p>
+    <div class="des 3des rijndael aes">
+    <div class="cbc ecb">
+    <button value="padding" class="buttonOff">Enable Padding</button>
+    <button value="padding" class="buttonOn disableCode">Disable Padding</button>
+    </div>
+    </div>
     <p>
       <button value="continuous" class="buttonOn">Enable Continuous Buffer</button>
       <button value="continuous" class="buttonOff disableCode">Disable Continuous Buffer</button>
@@ -252,7 +248,7 @@ $size = 10 * 1024;
 <span class="padding"><span class="ecb cbc"><span class="3des">$size-= 16; // make the plaintext length a multiple of the block length
 </span><span class="rijndael"><span class="b192">$size-= 16; // make the plaintext length a multiple of the block length
 </span></span><span class="rijndael"><span class="b224">$size-= 4; // make the plaintext length a multiple of the block length
-</span></span></span></span></span>$plaintext = str_repeat('a', $size);
+</span></span></span></span>$plaintext = str_repeat('a', $size);
 
 echo $cipher->decrypt($cipher->encrypt($plaintext));
 <span class="continuous">


### PR DESCRIPTION
The `<\span>` removal on https://github.com/phpseclib/docs/commit/bc22d9bac1831174efc7e05837ce441717548709#diff-5eba193060d0e7a066e99afe1ab0a94cR243 (fixing https://github.com/phpseclib/docs/issues/5) gave me the idea to check the source code validity of http://phpseclib.sourceforge.net/crypt/examples.html on https://validator.w3.org. There seem to be the following errors:

![validator_crypt_example](https://cloud.githubusercontent.com/assets/3662335/12472674/0b9d04f0-c00b-11e5-94d7-9955198b3483.png)

Note to points 3 and 4: Apparently `<p>` cannot contain `<div>` - see https://stackoverflow.com/questions/8397852/why-p-tag-cant-contain-div-tag-inside-it.

Curiously, Firefox, in its page source view, marks exactly the same places red and displays exactly the same mouse-over text as the validator errors. So, it seems to use the same syntax checker.

Those points are fixed in the commit here (tested copy-pasting the fixed page code as text (instead of the URL) into the validator).

But I noticed that other documentation pages have similar errors. So, before fixing further pages, I wanted to ask if the pages are created using some tool, or are they maintained completely manually?