### PR TITLE
add the 2.0 sample code and Composer support approach

### DIFF
--- a/2.0.html
+++ b/2.0.html
@@ -27,17 +27,30 @@
 $(document).ready(function() {
   $('.button').button();
   $('a').click(function() {
-    if($(this).attr('href') == '#rsaencrypt') {
+    if ($(this).attr('href') == '#rsaencrypt') {
       $('.prettyprint').html("&lt;?php\n\n" +
-        "require_once 'vendor/autoload.php'; // with Composer\n\n" +
+        "require_once 'vendor/autoload.php'; // with Composer\n" +
           "use phpseclib\Crypt\RSA;\n\n" +
           "$rsa = new RSA();\n" +
           "$rsa->loadKey('...'); // your public key\n" +
           "$rsa->setEncryptionMode(RSA::ENCRYPTION_PKCS1);\n" +
           "$result = $rsa->encrypt('your message  ');\n" +
           "echo $result;\n");
-    } else {
-      prettyPrint();
+    } else if ($(this).attr('href') == '#rsassh') {
+      $('.prettyprint').html("&lt;?php\n" +
+        "require_once 'vendor/autoload.php'; // with Composer\n" +
+        "use phpseclib\Crypt\RSA;\n" +
+        "use phpseclib\Net\SSH2;\n\n" +
+        "$key = new RSA();\n" +
+        "$key->loadKey(file_get_contents('private-key.txt'));\n\n" +
+        "// Domain can be an IP too\n" +
+        "$ssh = new SSH2('www.domain.tld');\n" +
+        "if (!$ssh->login('username', $key)) {\n" +
+        "    exit('Login Failed');\n" +
+        "}\n\n" +
+        "echo $ssh->exec('pwd');" +
+        "echo $ssh->exec('ls -la');"
+      );
     }
   });
 });

--- a/2.0.html
+++ b/2.0.html
@@ -26,6 +26,20 @@
 <script>
 $(document).ready(function() {
   $('.button').button();
+  $('a').click(function() {
+    if($(this).attr('href') == '#rsaencrypt') {
+      $('.prettyprint').html("&lt;?php\n\n" +
+        "require_once 'vendor/autoload.php'; // with Composer\n\n" +
+          "use phpseclib\Crypt\RSA;\n\n" +
+          "$rsa = new RSA();\n" +
+          "$rsa->loadKey('...'); // your public key\n" +
+          "$rsa->setEncryptionMode(RSA::ENCRYPTION_PKCS1);\n" +
+          "$result = $rsa->encrypt('your message  ');\n" +
+          "echo $result;\n");
+    } else {
+      prettyPrint();
+    }
+  });
 });
 </script>
 
@@ -69,18 +83,14 @@ tbody td {text-align: right }
     <h2>Examples:</h2>
     <ul>
       <li><a href="#rsassh">Log into SSH server with RSA key</a></li>
+      <li><a href="#rsaencrypt  ">Encrypt the message with the public key</a></li>
     </ul>
   </div>
   <div class="grid_8">
-    <p>These examples utilize <a href="https://github.com/composer/composer/blob/master/src/Composer/Autoload/ClassLoader.php">Composer's autoloader</a></p>
+    <p>These examples utilize <a href="https://getcomposer.org/">Composer</a></p>
     <h2 id="rsassh">Log into SSH server with RSA key</h2>
     <pre class="prettyprint">&lt;?php
-include 'autoload.php';
-
-$loader = new \Composer\Autoload\ClassLoader();
-$loader->addPsr4('phpseclib\\', __DIR__ . '/path/to/phpseclib2.0');
-$loader->register();
-
+require_once 'vendor/autoload.php'; // with Composer
 use phpseclib\Crypt\RSA;
 use phpseclib\Net\SSH2;
 

--- a/rsa/examples.html
+++ b/rsa/examples.html
@@ -168,9 +168,10 @@ ul { margin-bottom: 0 }
   <div class="grid_9">
     <div>
 <pre class="prettyprint" style="margin-bottom: 0">&lt;?php
-include('Crypt/RSA.php');
+include 'Crypt/RSA.php'; // without Composer
+require_once 'vendor/autoload.php'; // with Composer
 
-$rsa = new Crypt_RSA();
+$rsa = new \Crypt_RSA();
 <span class="timeout"> <!-- section -->
 <span class="encpkcs1 encputty">$rsa->setPassword('password');
 </span><span class="putty encputty">$rsa->setPrivateKeyFormat(CRYPT_RSA_PRIVATE_FORMAT_PUTTY);


### PR DESCRIPTION
It's for improving documentation in this [issue](https://github.com/phpseclib/phpseclib/issues/1202) comment.
# Changed log
- Add the Composer support approach
- Modify the sample code if installing the phpseclib via the Composer.
- Add the sample code of phpseclib 2.0.

I'm not sure that this changes is the good way.
Please review this and suggest the recommendation.
Then let me modify it.

Thanks.